### PR TITLE
Fixed bug. Laserscans now cover full 360 degrees.

### DIFF
--- a/velodyne_laserscan/src/VelodyneLaserScan.cpp
+++ b/velodyne_laserscan/src/VelodyneLaserScan.cpp
@@ -85,7 +85,7 @@ void VelodyneLaserScan::recvCallback(const sensor_msgs::PointCloud2ConstPtr& msg
   // Construct LaserScan message
   if ((offset_x >= 0) && (offset_y >= 0) && (offset_r >= 0)) {
     const float RESOLUTION = fabsf(cfg_.resolution);
-    const size_t SIZE = M_PI / RESOLUTION;
+    const size_t SIZE = 2.0 * M_PI / RESOLUTION;
     sensor_msgs::LaserScanPtr scan(new sensor_msgs::LaserScan());
     scan->header = msg->header;
     scan->angle_increment = RESOLUTION;


### PR DESCRIPTION
see comment here: https://github.com/ros-drivers/velodyne/pull/110#issuecomment-332667787